### PR TITLE
Cleaner printing and easier way to run examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,18 +12,3 @@ Depends:
     methods,
     stringr
 LazyData: true
-Collate:
-    'AggregateToR.r'
-    'CorrelationsToR.r'
-    'CrosstabToR.r'
-    'DescriptivesToR.r'
-    'FrequenciesToR.r'
-    'GraphToR.r'
-    'SPSStoR.r'
-    'SortCasesToR.r'
-    'TTestToR.r'
-    'ValueLabelsToR.r'
-    'descmat.r'
-    'getToR.r'
-    'getdataToR.r'
-    'semean.r'

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
+S3method(print,rsyntax)
 export(aggregate_to_r)
 export(correlations_to_r)
 export(crosstabs_to_r)

--- a/R/SPSStoR.r
+++ b/R/SPSStoR.r
@@ -79,6 +79,7 @@ spss_to_r <- function(file, writeRscript = FALSE, filePath = NULL){
     write.table(rsyntax, file = paste(filePath, '/rScript.r', sep = ''), row.names = FALSE, quote = FALSE,
                 col.names = FALSE)
   } else {
+    class(rsyntax) <- "rsyntax"
     rsyntax
   }
 }

--- a/R/print_rsyntax.R
+++ b/R/print_rsyntax.R
@@ -1,0 +1,11 @@
+#' Prints a rsyntax object
+#' 
+#' Prints a rsyntax object.
+#' 
+#' @param x The rsyntax object.
+#' @param \ldots ignored
+#' @method print rsyntax
+#' @S3method print rsyntax
+print.rsyntax <- function(x, ...){
+  cat(paste(x, collapse = "\n"), "\n")
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,7 +46,11 @@ Examples
 Multiple commands
 ------------------
 ```{r multiple}
- spss_to_r("inst/SPSSsyntax/getDescExamp.txt")
+# User won't be able to run this
+spss_to_r("inst/SPSSsyntax/getDescExamp.txt")
+# But this will work
+spss_to_r(system.file("SPSSsyntax", "getDescExamp.txt", package = "SPSStoR"))
+
 ```
 
 

--- a/man/print.rsyntax.Rd
+++ b/man/print.rsyntax.Rd
@@ -1,0 +1,15 @@
+\name{print.rsyntax}
+\alias{print.rsyntax}
+\title{Prints a rsyntax object}
+\usage{
+\method{print}{rsyntax}(x, ...)
+}
+\arguments{
+  \item{x}{The rsyntax object.}
+
+  \item{\ldots}{ignored}
+}
+\description{
+Prints a rsyntax object.
+}
+


### PR DESCRIPTION
I made a print method for the output so that you don't get the numbers in front of the printed output like so:
 [1] blah
 [2] other blah

I also slightly modified the README.Rmd to give an example of how the user could run the examples.  As they are written the user can't run the code in the README.  If you use system.file though they can access the examples.  It might not be bad to put that into the examples for the functions themselves.
